### PR TITLE
Correct Fastly, Add Bitbucket & Ghost

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ Shopify
 Fastly
 =====
 
-**Answer:** No :negative_squared_cross_mark: 
+**Answer:** Yes :heavy_check_mark:
 
-In Fastly, you can only takeover subdomains if you can prove ownership of the domain name. For example, if `something.example.com` is not claimed on Fastly, you would only be able to claim it in your account if you can prove ownership of the parent domain, `example.com`, in this case.
+In Fastly, subdomains can be taken over if the main domain doesn't already belong to a fastly account.
 
 Heroku
 ======

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Fastly
 
 **Answer:** Yes :heavy_check_mark:
 
-Subdomains can be taken over if the root domain doesn't already belong to a fastly account.
+Subdomains can be taken over if the root domain doesn't already belong to a Fastly account.
 
 Heroku
 ======

--- a/README.md
+++ b/README.md
@@ -212,3 +212,17 @@ Mashery
 The host should have CNAME record pointing to Mashery.
 
 Reference: https://hackerone.com/reports/275714
+
+Ghost
+=======
+
+**Answer:** Yes :heavy_check_mark:
+
+The host should have CNAME record pointing to `*.ghost.io`, also it costs $20 to host.
+
+Bitbucket
+=======
+
+**Answer:** Yes :heavy_check_mark:
+
+Similar to Github, the CNAME record will be pointing at `*.bitbucket.io`.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Fastly
 
 **Answer:** Yes :heavy_check_mark:
 
-In Fastly, subdomains can be taken over if the main domain doesn't already belong to a fastly account.
+Subdomains can be taken over if the root domain doesn't already belong to a fastly account.
 
 Heroku
 ======


### PR DESCRIPTION
Fastly subdomains can be taken over without domain ownership. Still works as of 5 minutes ago.