### PR TITLE
Adding first test-case (as discussed in #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Check for an A record pointing to 66.6.44.4 with a subsequent 'Not found.' on th
 
 Tilda doesn't let you take subdomains that have been used for an old project even if the original subsription has expired.
 
+### Test Cases
+[x] Unsuccessful attempt to claim current sub-domain
+[x] Successful attempt to claim other sub-domains for tld
+
 ## Google Cloud Storage
 **Answer:** No :negative_squared_cross_mark: 
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Check for an A record pointing to 66.6.44.4 with a subsequent 'Not found.' on th
 
 Tilda doesn't let you take subdomains that have been used for an old project even if the original subsription has expired.
 
-### Test Cases
+### Test Cases (30th June 2018)
 [x] Unsuccessful attempt to claim current sub-domain
 [x] Successful attempt to claim other sub-domains for tld
 


### PR DESCRIPTION
As discussed in #19 I'm adding the first test case under Tilda.

I think it would be worthwhile retro-actively adding these to other takeovers (particularly where a takeover is listed as not possible) to help give more insight to future visitors.

On that note - I'm also adding a date to the test cases should somebody wish to re-perform them a year or two after they are first run and update the repository.