### PR TITLE
Statuspage no longer vulnerable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Readme.io | Vulnerable | `Project doesnt exist... yet!` | [Issue #41](https://gi
 Sendgrid                         | Not vulnerable |                                                                         |
 Shopify                           | Edge Case     | `Sorry, this shop is currently unavailable.`                            |[Issue #32](https://github.com/EdOverflow/can-i-take-over-xyz/issues/32), [Issue #46](https://github.com/EdOverflow/can-i-take-over-xyz/issues/46)| [Medium Article](https://medium.com/@thebuckhacker/how-to-do-55-000-subdomain-takeover-in-a-blink-of-an-eye-a94954c3fc75) 
 Squarespace                   | Not vulnerable |                                                                         |
-Statuspage                     | Vulnerable     | `You are being redirected`                                              | [HackerOne #49663](https://hackerone.com/reports/49663)
+Statuspage                     | Not vulnerable |                                                                         |
 Surge.sh                         | Vulnerable     | `project not found`                                                     || [Surge Documentation](https://surge.sh/help/adding-a-custom-domain)
 Tumblr                             | Vulnerable     | `Whatever you were looking for doesn't currently exist at this address` |
 Tilda                               | Edge Case | `Please renew your subscription`                                        | [PR #20](https://github.com/EdOverflow/can-i-take-over-xyz/pull/20)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Readme.io | Vulnerable | `Project doesnt exist... yet!` | [Issue #41](https://gi
 Sendgrid                         | Not vulnerable |                                                                         |
 Shopify                           | Edge Case     | `Sorry, this shop is currently unavailable.`                            |[Issue #32](https://github.com/EdOverflow/can-i-take-over-xyz/issues/32), [Issue #46](https://github.com/EdOverflow/can-i-take-over-xyz/issues/46)| [Medium Article](https://medium.com/@thebuckhacker/how-to-do-55-000-subdomain-takeover-in-a-blink-of-an-eye-a94954c3fc75) 
 Squarespace                   | Not vulnerable |                                                                         |
-Statuspage                     | Not vulnerable |                                                                         |
+Statuspage                     | Not vulnerable |                                                                         | [PR #65](https://github.com/EdOverflow/can-i-take-over-xyz/pull/65)
 Surge.sh                         | Vulnerable     | `project not found`                                                     || [Surge Documentation](https://surge.sh/help/adding-a-custom-domain)
 Tumblr                             | Vulnerable     | `Whatever you were looking for doesn't currently exist at this address` |
 Tilda                               | Edge Case | `Please renew your subscription`                                        | [PR #20](https://github.com/EdOverflow/can-i-take-over-xyz/pull/20)


### PR DESCRIPTION
Statuspage no longer vulnerable to subdomain takeover because they ask users to put this `[unique_string].stspg-customer.com` in CNAME instead of just `statuspage.io`

https://help.statuspage.io/knowledge_base/topics/domain-ownership - Custom Domain