### PR TITLE
Update Mashery to Edge Case

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Help Scout                     | Vulnerable     | `No settings were found for th
 Heroku                             | Edge case     | `No such app`                                                           | [Issue #38](https://github.com/EdOverflow/can-i-take-over-xyz/issues/38)
 JetBrains                       | Vulnerable     | `is not a registered InCloud YouTrack`                                  |
 Kinsta                           | Vulnerable     | `No Site For Domain`                                                 |[Issue #48](https://github.com/EdOverflow/can-i-take-over-xyz/issues/48) | [kinsta-add-domain](https://kinsta.com/knowledgebase/add-domain/)
-Mashery                           | Not vulnerable | `Unrecognized domain`                                                   | [HackerOne #275714](https://hackerone.com/reports/275714), [Issue #14](https://github.com/EdOverflow/can-i-take-over-xyz/issues/14)
+Mashery                           | Edge Case | `Unrecognized domain`                                                   | [HackerOne #275714](https://hackerone.com/reports/275714), [Issue #14](https://github.com/EdOverflow/can-i-take-over-xyz/issues/14)
 Microsoft Azure           | Vulnerable     |  | [Issue #35](https://github.com/EdOverflow/can-i-take-over-xyz/issues/35) |
 Netlify | Edge Case | | [Issue #40](https://github.com/EdOverflow/can-i-take-over-xyz/issues/40) |
 Readme.io | Vulnerable | `Project doesnt exist... yet!` | [Issue #41](https://github.com/EdOverflow/can-i-take-over-xyz/issues/41)


### PR DESCRIPTION
Mashery takeovers do appear to be able to be claimed by a paid account. Although manually approved by Mashery support the process doesn't not appear to consistently include verification company ownership, and does not require any DNS changes (such as an A record) to prove domain ownership to be made.