### PR TITLE
Create CONTRIBUTING.md (w/ Markdown Links)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+### Fingerprint Conributors Over Time
+
+[Muhammad Khizer Javed](https://github.com/MuhammadKhizerJaved)  
+[Evgeniy Yakovchuk](https://github.com/sp1d3r)  
+[Avileox](https://github.com/Avileox)  
+[AmanShahid](https://github.com/AmanShahid)  
+[The Mysterious Cyber Warriors](https://github.com/gauravdrago)  
+[m7mdharoun](https://github.com/m7mdharoun)  
+[Mohamed Elbadry](https://github.com/melbadry9)  
+[Talksec](https://github.com/TakSec)  
+[Rajat Moury](https://github.com/messi96)  
+[Spam404](https://github.com/Spam404)  
+[r0hack](https://github.com/r0hack)  
+[Quinten](https://github.com/Quikko)  
+[jatoch](https://github.com/jatoch)  
+[itachi73](https://github.com/itachi73)  
+[LinuxSec](https://github.com/linuxsec)  
+[Patrik Hudak](https://github.com/PatrikHudak)  


### PR DESCRIPTION
This list was compiled by [GDATTACKER-RESEARCHER](https://github.com/GDATTACKER-RESEARCHER) back in 2020, per pull #180, but never updated with Markdown links as requested by @EdOverflow. This version of the list contains the Markdown links.