### PR TITLE
Adding "web.core.windows.net" for Azure subdomain takeover

### DIFF
--- a/fingerprints.json
+++ b/fingerprints.json
@@ -558,7 +558,8 @@
       "redis.cache.windows.net",
       "azurehdinsight.net",
       "servicebus.windows.net",
-      "visualstudio.com"
+      "visualstudio.com",
+      "web.core.windows.net"
     ],
     "discussion": "[Issue #35](https://github.com/EdOverflow/can-i-take-over-xyz/issues/35)",
     "documentation": "",


### PR DESCRIPTION
I was only find this [link](https://falconforce.nl/arbitrary-1-click-azure-tenant-takeover-via-ms-application/) which briefly mentions this type of Azure resource for subdomain takeover. However, it is possible.